### PR TITLE
Add a try/except to make the deadline optional.

### DIFF
--- a/runestone/assignment/__init__.py
+++ b/runestone/assignment/__init__.py
@@ -79,7 +79,11 @@ class Assignment(RunestoneDirective):
         assignment_type_id = getOrCreateAssignmentType(assignment_type_name)
 
         if 'deadline' in self.options:
-            deadline = datetime.strptime(self.options['deadline'], '%Y-%m-%d %H:%M')
+            try:
+                deadline = datetime.strptime(self.options['deadline'], '%Y-%m-%d %H:%M')
+            except:
+                deadline = None
+                raise self.warn("Deadline for assignment {} not a valid date/time of %Y-%m-%d %H:%M format".format(self.options['name']))
         else:
             deadline = None
         points = self.options.get('points', 0)


### PR DESCRIPTION
This can ameliorate likely RST errors, but it's not necessary. I think it's likely for humans to put the `:deadline:` option in and then not fill it in, which generates a build error without this. But, as it is in this branch, you either have one with a valid strptime, or you don't have one at all, and those are your options, which is also OK, of course, in which case we don't need to add this.

PR to you at moment but if all think this is a good idea I can move it, and if not we can close it.
