### PR TITLE
Add option to exclude all subchapters from usageassignment that include "exercises"

### DIFF
--- a/runestone/usageAssignment/__init__.py
+++ b/runestone/usageAssignment/__init__.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 from __future__ import print_function
-import logging
 
 __author__ = 'Paul Resnick'
 

--- a/runestone/usageAssignment/__init__.py
+++ b/runestone/usageAssignment/__init__.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 from __future__ import print_function
+import logging
 
 __author__ = 'Paul Resnick'
 
@@ -57,10 +58,18 @@ def visit_ua_node(self,node):
         chapter_data = None
 
     s = ""
+    chapters_and_subchapters = {}
     if chapter_data and course_name:
-        for d in chapter_data:
+        for d in chapter_data: # Set up Chapter-Subchs dictionary
             ch_name, sub_chs = d['ch'], d['sub_chs']
-            s += '<div class="panel-heading">'
+            if d['ch'] not in chapters_and_subchapters:
+                chapters_and_subchapters[d['ch']] = [x for x in d['sub_chs']]
+            else:
+                for subch in d['sub_chs']:
+                    chapters_and_subchapters[d['ch']].append(subch)
+
+        for ch_name,sub_chs in chapters_and_subchapters.items():
+            s += '<div style="margin-left:150px;" class="panel-heading">'
             s += ch_name
             s += '<ul class="list-group">'
             for sub_ch_name in sub_chs:
@@ -70,7 +79,7 @@ def visit_ua_node(self,node):
             s += '</ul>'
             s += '</div>'
 
-    # is this needed??
+    # is this needed?? 
     s = s.replace("u'","'")  # hack:  there must be a better way to include the list and avoid unicode strings
 
     self.body.append(s)

--- a/runestone/usageAssignment/__init__.py
+++ b/runestone/usageAssignment/__init__.py
@@ -62,7 +62,10 @@ def visit_ua_node(self,node):
         for d in chapter_data: # Set up Chapter-Subchs dictionary
             ch_name, sub_chs = d['ch'], d['sub_chs']
             if d['ch'] not in chapters_and_subchapters:
-                chapters_and_subchapters[d['ch']] = [x for x in d['sub_chs']]
+                if 'no_exercises' in self.options:
+                    chapters_and_subchapters[d['ch']] = [x for x in d['sub_chs'] if "exercises" not in x.lower()]
+                else:
+                    chapters_and_subchapters[d['ch']] = [x for x in d['sub_chs']]
             else:
                 for subch in d['sub_chs']:
                     chapters_and_subchapters[d['ch']].append(subch)
@@ -109,6 +112,7 @@ class usageAssignment(Directive):
    :deadline: <str>
    :sections: <comma separated int ids of the section objects; kind of a hack>
    :pct_required: <int>   :points: <int>
+   :no_exercises: [optional argument to not include exercises subchs]
 
     """
     required_arguments = 0  # use assignment_name parameter


### PR DESCRIPTION
What do you think about this, @presnick?

This assumes my previous commit to fix the subchapter thing is already committed. However, it allows us to specify whole chapters, too, and just not include any subchapter that has "exercises" in its name. PIP has no chapters like this... I think it will frequently make sense, with a naming convention where "exercises" is only included in subchapters/sections that are primarily exercises, and often, the usage assignment doesn't make as much sense there, since threshold is looking at whether a student did a certain percent of exercises in a whole reading set.

Could even be generalizable if that naming convention seems acceptable.
