### PR TITLE
When clicking the 'Next Step' button in a Parson, we should disable t…

### DIFF
--- a/runestone/showeval/js/showEval.js
+++ b/runestone/showeval/js/showEval.js
@@ -135,13 +135,13 @@ var SHOWEVAL = (function () {
                 if (thisShowEval.currentStep < thisShowEval.steps.length) {
                   thisShowEval.setStep(thisShowEval.currentStep);
                 }
+                $(buttonId).attr("disabled", false);
               }, 600);
             });
           });
         });
       }, 600);
     });
-    $(buttonId).attr("disabled", false);
     this.rb.logBookEvent({"event": "showeval", "act": 'next', "div_id": this.container[0].id});
 
   };


### PR DESCRIPTION
…he button till the animation is over. However, the code enabled the button immediately without waiting for the animation to end. I sloved the issue.